### PR TITLE
Add shutdown by HTTP

### DIFF
--- a/main.go
+++ b/main.go
@@ -339,9 +339,9 @@ func (p *ProxyService) shutdownTarget(targetName string) error {
 	}
 
 	target := targetState.Target
-	if (target.SSHHost == "" || target.SSHUser == "" || target.SSHKeyPath == "" || target.ShutdownCommand == "") && target.ShutdownHTTPUrl == "" {
-		return fmt.Errorf("target %s is missing SSH configuration or shutdown command or shutdown HTTP URL", targetName)
-	}
+    if (target.SSHHost == "" || target.SSHUser == "" || target.SSHKeyPath == "" || target.ShutdownCommand == "") && target.ShutdownHTTPUrl == "" {
+        return fmt.Errorf("target %s is missing SSH configuration or shutdown command or shutdown HTTP URL", targetName)
+    }
 
 	p.logger.Info("Shutting down target %s (%s) due to inactivity", targetName, target.Hostname)
 	if target.ShutdownHTTPUrl != "" {
@@ -351,15 +351,10 @@ func (p *ProxyService) shutdownTarget(targetName string) error {
 			method = "POST" // Default to POST if not specified
 		}
 
-		okStatus := target.ShutdownHTTPOKStatus
-		if okStatus == 0 {
-			okStatus = http.StatusOK // Default to 200 if not specified
-		}
-
-		req, err := http.NewRequest(method, target.ShutdownHTTPUrl, nil)
-		if err != nil {
-			return fmt.Errorf("failed to create shutdown request: %w", err)
-		}
+        req, err := http.NewRequest(method, target.ShutdownHTTPUrl, nil)
+        if err != nil {
+            return fmt.Errorf("failed to create shutdown request: %w", err)
+        }
 
 		// Send the request
 		client := &http.Client{
@@ -371,9 +366,14 @@ func (p *ProxyService) shutdownTarget(targetName string) error {
 		}
 		defer resp.Body.Close()
 
-		if resp.StatusCode != okStatus {
-			return fmt.Errorf("shutdown request failed with status: %s", resp.Status)
-		}
+        // Accept any 2xx status by default; allow explicit status override
+        if target.ShutdownHTTPOKStatus != 0 {
+            if resp.StatusCode != target.ShutdownHTTPOKStatus {
+                return fmt.Errorf("shutdown request failed with status: %s", resp.Status)
+            }
+        } else if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+            return fmt.Errorf("shutdown request failed with status: %s", resp.Status)
+        }
 
 	} else {
 		err := p.sshExecutor.ExecuteCommand(target.SSHHost, target.SSHUser, target.SSHKeyPath, target.ShutdownCommand)
@@ -775,10 +775,10 @@ func LoadConfig(filename string) (*ProxyConfig, error) {
 	hostnameMap := make(map[string]string)
 	inactivityThresholds := make(map[string]time.Duration)
 
-	for _, target := range config.Targets {
-		if target.Hostname == "" {
-			return nil, fmt.Errorf("target %s is missing hostname", target.Name)
-		}
+    for _, target := range config.Targets {
+        if target.Hostname == "" {
+            return nil, fmt.Errorf("target %s is missing hostname", target.Name)
+        }
 
 		// Check for duplicate hostnames
 		if existingTarget, exists := hostnameMap[target.Hostname]; exists {
@@ -786,12 +786,23 @@ func LoadConfig(filename string) (*ProxyConfig, error) {
 				target.Hostname, existingTarget, target.Name)
 		}
 
-		// Parse inactivity threshold if provided
-		if target.InactivityThreshold != "" {
-			inactivityThreshold, err := time.ParseDuration(target.InactivityThreshold)
-			if err != nil {
-				return nil, fmt.Errorf("invalid inactivity_threshold for target %s: %w", target.Name, err)
-			}
+        // Validate shutdown configuration
+        // Disallow using both SSH shutdown command and HTTP shutdown URL
+        if strings.TrimSpace(target.ShutdownHTTPUrl) != "" && strings.TrimSpace(target.ShutdownCommand) != "" {
+            return nil, fmt.Errorf("target %s: cannot define both shutdown_http_url and shutdown_command; choose one", target.Name)
+        }
+
+        // Disallow http method/ok status without URL
+        if strings.TrimSpace(target.ShutdownHTTPUrl) == "" && (strings.TrimSpace(target.ShutdownHTTPMethod) != "" || target.ShutdownHTTPOKStatus != 0) {
+            return nil, fmt.Errorf("target %s: shutdown_http_method and/or shutdown_http_ok_status require shutdown_http_url to be set", target.Name)
+        }
+
+        // Parse inactivity threshold if provided
+        if target.InactivityThreshold != "" {
+            inactivityThreshold, err := time.ParseDuration(target.InactivityThreshold)
+            if err != nil {
+                return nil, fmt.Errorf("invalid inactivity_threshold for target %s: %w", target.Name, err)
+            }
 			inactivityThresholds[target.Name] = inactivityThreshold
 		}
 


### PR DESCRIPTION
Hey!
First of all, great project! I use it on a few machines and it works great.

The only thing I found missing is the option to shutdown by HTTP rather than SSH(for example when using [this](https://github.com/AdarWa/RemoteShutdown) or a similar project). I find it very useful and a great addition to this awesome project.

Please see the changes I've made below.

I'm here for any questions.

Best regards,
Adar