### PR TITLE
response_header_timeout in config.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@ A Wake-on-LAN proxy service written in Go that automatically wakes up servers wh
 The service is configured using a TOML file. Here's an example configuration:
 
 ```toml
-port = ":8080"                 # Port to listen on
-timeout = "1m"                 # How long to wait for server to wake up
-poll_interval = "5s"           # How often to check health during wake-up
-health_check_interval = "30s"  # Background health check frequency
-health_cache_duration = "10s"  # How long to trust cached health status
+port = ":8080"                  # Port to listen on
+timeout = "1m"                  # How long to wait for server to wake up
+response_header_timeout = "1m"  # How long to wait for a response header, e.g. during or after slow or long-running requests/uploads
+poll_interval = "5s"            # How often to check health during wake-up
+health_check_interval = "30s"   # Background health check frequency
+health_cache_duration = "10s"   # How long to trust cached health status
 
 # Optional SSL configuration Do not add these values unless you plan to use TLS/HTTPS
 ssl_certificate = "/path/to/cert.pem"   # Path to your SSL certificate

--- a/config.toml
+++ b/config.toml
@@ -1,8 +1,9 @@
-port = ":8080"                 # Port to listen on
-timeout = "1m"                 # How long to wait for server to wake up
-poll_interval = "5s"           # How often to check health during wake-up
-health_check_interval = "30s"  # Background health check frequency
-health_cache_duration = "10s"  # How long to trust cached health status
+port = ":8080"                  # Port to listen on
+timeout = "1m"                  # How long to wait for server to wake up
+response_header_timeout = "1m"  # How long to wait for a response header, e.g. during or after slow or long-running requests/uploads
+poll_interval = "5s"            # How often to check health during wake-up
+health_check_interval = "30s"   # Background health check frequency
+health_cache_duration = "10s"   # How long to trust cached health status
 
 [[targets]]
 name = "service"


### PR DESCRIPTION
This PR replaces the hard-coded 60 second response header timeout value with a new value `response_header_timeout` in the `config.toml` file.
Adjusting this value will allow long-running requests that don't return a response within 60 seconds to continue running instead of being aborted.

This fixes an issue in conjunction with my local llama-cpp instance when uploading large contexts that the LLM has to process first before returning a response. Depending on the model and contexts size this can take several minutes, so this adjustment was required.